### PR TITLE
Implement YouTube link submission and API request handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	//implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok:1.18.28'
 	annotationProcessor 'org.projectlombok:lombok:1.18.28'

--- a/src/main/java/PlayList/Matcher/controller/CallbackController.java
+++ b/src/main/java/PlayList/Matcher/controller/CallbackController.java
@@ -15,7 +15,7 @@ public class CallbackController {
     private AuthService authService;
     private static final Logger log = Logger.getLogger(CallbackController.class.getName());
 
-    //스포티파이 개발자 계정에 등록해놓은 redirect url이 http://localhost:8080/callback
+    //스포티파이 개발자 계정에 등록해놓은 redirect url이 http://localhost:8080/callback이다
     @GetMapping("/callback")
     public String callback(@RequestParam String code){
         String accessToken = authService.requestAccessToken(code);

--- a/src/main/java/PlayList/Matcher/controller/LinkController.java
+++ b/src/main/java/PlayList/Matcher/controller/LinkController.java
@@ -1,0 +1,45 @@
+package PlayList.Matcher.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/link")
+public class LinkController {
+
+    private final WebClient webClient;
+
+    public LinkController(WebClient.Builder webClientBuilder, @Value("${python.server.url}") String pythonServerUrl) {
+        this.webClient = webClientBuilder.baseUrl(pythonServerUrl).build();
+    }
+
+    @PostMapping("/send-link")
+    public Mono<Map> sendYouTubeLink(@RequestBody Map<String, String> request) {
+
+        if (!request.containsKey("youtubeUrl")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing 'youtubeUrl' in request.");
+        }
+
+        String youtubeUrl = request.get("youtubeUrl");
+        System.out.println("Received YouTube URL: " + youtubeUrl);
+
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("youtubeUrl", youtubeUrl);
+
+        return webClient.post()
+                .uri("/process-link")
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(Map.class);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spotify.token-uri=https://accounts.spotify.com/api/token
 
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 
+
+#Connection with Python
+python.server.url=http://localhost:5000

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>YouTube 링크 입력</title>
+    <script>
+        function sendYouTubeLink() {
+            let youtubeLink = document.getElementById("youtubeLink").value;
+
+            fetch("/link/send-link", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ "youtubeUrl": youtubeLink })
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById("result").innerText = "Python 응답: " + JSON.stringify(data);
+            })
+            .catch(error => console.error("Error:", error));
+        }
+    </script>
+</head>
+<body>
+<h2>YouTube 링크 입력</h2>
+<input type="text" id="youtubeLink" placeholder="YouTube 링크 입력">
+<button onclick="sendYouTubeLink()">전송</button>
+
+<h3>응답 결과:</h3>
+<p id="result"></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Spring Boot에서 WebClient를 이용하여 Flask 서버와 통신하는 기능을 추가
- YouTube 링크를 입력하면 Flask 서버로 전달하는 기능을 구현
- 간단한 메인화면 html 작성

## Why?
- YouTube 링크를 분석하는 기능이 Flask 서버에서 실행되므로, Spring Boot에서 이를 전달하는 API가 필요

## Changes
- LinkController.java 추가
- /link/send-link 엔드포인트 구현 (WebClient 사용)
- 프론트엔드(Thymeleaf)에서 YouTube 링크를 입력하면 요청을 보내는 기능 추가
- application.properties에 python.server.url=http://localhost:5000 추가
- build.gradle에 thymeleaf 의존성 추가

## How to Test?
1. Spring Boot 실행
2. Flask 서버 실행: python python_server.py ->python3인 사람은 python3
3. http://localhost:8080 에서 YouTube 링크 입력 후 전송 버튼 클릭
4. Flask 로그에서 요청을 정상적으로 받았는지 확인
5. 응답이 프론트엔드에 표시되는지 확인