### PR TITLE
feat:로그아웃/계정변경 추가

### DIFF
--- a/src/main/java/PlayList/Matcher/config/CorsConfig.java
+++ b/src/main/java/PlayList/Matcher/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package PlayList.Matcher.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowCredentials(true); // 쿠키 및 인증정보 허용
+        config.setAllowedOrigins(List.of("http://localhost:8080")); // 허용할 도메인
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
+        config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
+
+        source.registerCorsConfiguration("/**", config); // 모든 경로에서 CORS 허용
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/PlayList/Matcher/config/SecurityConfig.java
+++ b/src/main/java/PlayList/Matcher/config/SecurityConfig.java
@@ -10,10 +10,10 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf->csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll() // 모든 요청 허용
                 )
-                .csrf(csrf->csrf.disable())// CSRF 비활성화
                 .formLogin(formLogin->formLogin.disable()); // 기본 로그인 페이지 비활성화
 
         return http.build();

--- a/src/main/java/PlayList/Matcher/controller/LogoutController.java
+++ b/src/main/java/PlayList/Matcher/controller/LogoutController.java
@@ -1,11 +1,16 @@
 package PlayList.Matcher.controller;
 
 import PlayList.Matcher.service.AuthService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@Slf4j
+@RestController // ✅ @RestController로 변경
+@RequestMapping("/api") // ✅ 명확한 경로 추가
+@CrossOrigin(origins = "http://localhost:8080", allowCredentials = "true")
 public class LogoutController {
     private final AuthService authService;
 
@@ -13,12 +18,34 @@ public class LogoutController {
         this.authService = authService;
     }
 
-    @GetMapping("/logout")
-    public String logout(@RequestParam(required = false) String redirect) {
+//    @GetMapping("/logout")
+//    public String logout(@RequestParam(required = false) String redirect) {
+//        authService.logout();
+//        if ("login".equals(redirect)) {
+//            return "redirect:/login";
+//        }
+//        return "redirect:/index.html";
+//    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(){
+        log.info("로그아웃 수신");
         authService.logout();
-        if ("login".equals(redirect)) {
-            return "redirect:/login";
-        }
-        return "redirect:/index.html";
+
+        return ResponseEntity.ok("로그아웃 완료");
+        // String redirectUrl=(redirect!=null&&redirect.equals("login"))?"/login":"/";
+//        String logoutUrl = "https://www.spotify.com/logout/";
+//        return ResponseEntity.status(302)
+//                .header(HttpHeaders.LOCATION, logoutUrl)
+//                .build();
     }
+
+//    @PostMapping("/change-account")
+//    public ResponseEntity<String> changeAccount(){
+//        log.info("계정변경 수신");
+//
+//        authService.logout();
+//
+//        return ResponseEntity.ok("/login");
+//    }
 }

--- a/src/main/java/PlayList/Matcher/service/AuthService.java
+++ b/src/main/java/PlayList/Matcher/service/AuthService.java
@@ -86,10 +86,13 @@ public class AuthService {
         return spotifyAccessToken;
     }
     public String getAccessToken() {
-//        if (spotifyAccessToken == null || System.currentTimeMillis() > spotifyAccessExpires) {
-//            throw new RuntimeException("Spotify access token expired. Please re-authenticate.");
-//        }
+        if (spotifyAccessToken == null) {
+            throw new RuntimeException("No access token available. Please log in.");
+        }
         if(isAccessTokenExpired()){
+            if (spotifyRefreshToken == null) {
+                throw new RuntimeException("No refresh token available. Please re-authenticate.");
+            }
             log.info("access token 만료. token을 refresh 합니다");
             return refreshAccessToken();
         }
@@ -102,6 +105,7 @@ public class AuthService {
     }
 
     public void logout() {
+        log.info("access token, refresh token 삭제");
         this.spotifyAccessToken = null;
         this.spotifyRefreshToken = null;
         this.spotifyAccessExpires = 0L;

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -106,6 +106,7 @@
                     showUserInfo(data);
                 })
                 .catch(error => {
+                 console.log("사용자가 로그인되어 있지 않습니다.");
                     // 로그인되지 않은 상태: 로그인 버튼 표시
                     showLoginButton();
                 });
@@ -130,12 +131,33 @@
           <p>안녕하세요, <strong>${displayName}</strong>님!</p>
           <p><small>사용자: ${userData.displayName || '정보 없음'}</small></p>
           <p><small>이메일: ${userData.email || '정보 없음'}</small></p>
-          <button class="logout-button" onclick="window.location.href='/logout'">로그아웃</button>
-          <button class="change-account-button" onclick="window.location.href='/logout?redirect=login'">계정 변경하기</button>
+          <button class="logout-button" onclick="logout()">로그아웃</button>
+          <button class="change-account-button" onclick="changeAccount()">계정 변경하기</button>
         </div>
       `;
         }
+        function logout() {
+        console.log("로그아웃 버튼 클릭됨");
+        fetch('/api/logout', { method: 'POST', credentials: 'include' })
+            .then(response => {
+                if (response.ok) {
+                    console.log("로그아웃 성공");
+                    window.location.href = "/"; // 홈으로 리디렉트
+                } else {
+                    console.error("로그아웃 실패");
+                }
+            })
+            .catch(error => console.error("로그아웃 실패:", error));
+        }
 
+<!--        function changeAccount(){-->
+<!--        console.log("계정변경 버튼 클릭됨");-->
+<!--        fetch('/api/change-account', { method: 'POST', credentials: 'include' })-->
+<!--            .then(response => response.text())-->
+<!--            .then(url => window.location.href = url;)-->
+<!--            .catch(error => console.error("계정 변경 실패:", error));-->
+<!--        }-->
+        }
         // 1. 유튜브 링크 전송 및 플레이리스트 정보 수신
         function sendYouTubeLink() {
             let youtubeLink = document.getElementById("youtubeLink").value;
@@ -301,7 +323,6 @@
                     document.getElementById("match-results").innerHTML = "매칭된 트랙을 가져오는 중 오류가 발생했습니다: " + error.message;
                 });
         }
-
         function displayMatchResults(matchedData) {
             const matchResultsDiv = document.getElementById("match-results");
             matchResultsDiv.innerHTML = "<h3>매칭 결과</h3>";


### PR DESCRIPTION
- 사용자 로그아웃 시 내부 토큰 초기화 및 Spotify 로그아웃 페이지로 이동
- 계정 변경 버튼 추가: 로그아웃 후 새로운 계정으로 재로그인 가능
- LogoutController에 /logout, /change-account 엔드포인트 구현
- index.html에 JS 함수(logout, changeAccount) 추가 및 버튼 연결
- UX 향상을 위해 Spotify 로그아웃 페이지는 새 창으로 처리 후 자동 닫힘
